### PR TITLE
2 - now we've got a dimension trait. Can make things generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # upper_tri
 an upper triangular matrix library written in rust. Starting with dynamically sized square matrices
 , for a symmetric matrix use case.
+
+Note the idea in general is for these to be big, so they are heap assigned.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@ an upper triangular matrix library written in rust. Starting with dynamically si
 , for a symmetric matrix use case.
 
 Note the idea in general is for these to be big, so they are heap assigned.
+
+For the eventual static version it would make sense to have a small stack 
+assigned version as well

--- a/src/dimension.rs
+++ b/src/dimension.rs
@@ -1,7 +1,9 @@
+/// A trait for square upper triangle matrices
 pub trait SquareDimension {
     fn to_usize(&self) -> usize;
 }
 
+/// A dynamic dimension.  For matrices that will need to be resized at runtime
 #[derive(Clone, Copy, PartialEq, PartialOrd)]
 pub struct DynSquare(pub(crate) usize);
 

--- a/src/dimension.rs
+++ b/src/dimension.rs
@@ -1,0 +1,24 @@
+pub trait SquareDimension {
+    fn to_usize(&self) -> usize;
+}
+
+#[derive(Clone, Copy, PartialEq, PartialOrd)]
+pub struct DynSquare(pub(crate) usize);
+
+impl SquareDimension for DynSquare {
+    fn to_usize(&self) -> usize {
+        self.0
+    }
+}
+
+impl DynSquare {
+    pub(crate) fn grow(&mut self) {
+        self.0 += 1;
+    }
+
+    pub(crate) fn shrink(&mut self) {
+        if self.0 > 0 {
+            self.0 -= 1
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod dimension;
 pub mod upper_tri_data;
 #[cfg(test)]
 mod tests {

--- a/src/upper_tri_data.rs
+++ b/src/upper_tri_data.rs
@@ -1,3 +1,5 @@
+use crate::dimension::DynSquare;
+use crate::dimension::SquareDimension;
 use core::slice::Iter;
 use std::fmt::Display;
 use std::iter::repeat;
@@ -13,9 +15,9 @@ use std::vec::IntoIter;
 use rand_distr::num_traits::Zero;
 
 #[derive(Clone)]
-pub struct UpperTriRawData<T> {
+pub struct UpperTriRawData<T, D: SquareDimension + Clone> {
     buf: Vec<T>,
-    pub rank: usize,
+    pub rank: D,
 }
 
 // Need to guarantee that row <= col
@@ -31,29 +33,29 @@ fn offset_for_col(col: usize, row: usize) -> usize {
 }
 
 /// A struct for reading the component strictly above the diagonal
-pub struct ColView<RefType, BaseType> {
+pub struct ColView<RefType, BaseType, D: SquareDimension> {
     ptr: *const BaseType,
     col_num: usize,
-    rank: usize,
+    rank: D,
     row: usize,
     col_offset: usize,
     _ref_type: PhantomData<RefType>,
 }
 
 /// A struct for writing the component strictly above the diagonal
-pub struct ColViewMut<RefType, BaseType> {
+pub struct ColViewMut<RefType, BaseType, D: SquareDimension> {
     ptr: *mut BaseType,
     col_num: usize,
     row: usize,
-    rank: usize,
+    rank: D,
     col_offset: usize,
     _ref_type: PhantomData<RefType>,
 }
 
-impl<'a, T: 'a> Iterator for ColViewMut<&'a mut T, T> {
+impl<'a, T: 'a, D: SquareDimension> Iterator for ColViewMut<&'a mut T, T, D> {
     type Item = &'a mut T;
     fn next(&mut self) -> Option<&'a mut T> {
-        if self.col_num >= self.rank || self.row >= self.col_num {
+        if self.col_num >= self.rank.to_usize() || self.row >= self.col_num {
             None
         } else {
             unsafe {
@@ -70,10 +72,10 @@ impl<'a, T: 'a> Iterator for ColViewMut<&'a mut T, T> {
     }
 }
 
-impl<'a, T: 'a> Iterator for ColView<&'a T, T> {
+impl<'a, T: 'a, D: SquareDimension> Iterator for ColView<&'a T, T, D> {
     type Item = &'a T;
     fn next(&mut self) -> Option<&'a T> {
-        if self.col_num >= self.rank || self.row >= self.col_num {
+        if self.col_num >= self.rank.to_usize() || self.row >= self.col_num {
             None
         } else {
             unsafe {
@@ -91,27 +93,27 @@ impl<'a, T: 'a> Iterator for ColView<&'a T, T> {
 }
 
 /// A struct for reading the component strictly to the left of the diagonal
-pub struct RowView<RefType, BaseType> {
+pub struct RowView<RefType, BaseType, D: SquareDimension> {
     ptr: *const BaseType,
     row_num: usize,
-    rank: usize,
+    rank: D,
     col: usize,
     _ref_type: PhantomData<RefType>,
 }
 
 /// A struct for writing the component strictly to the left of the diagonal
-pub struct RowViewMut<RefType, BaseType> {
+pub struct RowViewMut<RefType, BaseType, D: SquareDimension> {
     ptr: *mut BaseType,
     row_num: usize,
     col: usize,
-    rank: usize,
+    rank: D,
     _ref_type: PhantomData<RefType>,
 }
 
-impl<'a, T: 'a> Iterator for RowView<&'a T, T> {
+impl<'a, T: 'a, D: SquareDimension> Iterator for RowView<&'a T, T, D> {
     type Item = &'a T;
     fn next(&mut self) -> Option<&'a T> {
-        if self.col >= self.rank {
+        if self.col >= self.rank.to_usize() {
             None
         } else {
             unsafe {
@@ -123,15 +125,15 @@ impl<'a, T: 'a> Iterator for RowView<&'a T, T> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.rank - self.col;
+        let remaining = self.rank.to_usize() - self.col;
         (remaining, Some(remaining))
     }
 }
 
-impl<'a, T: 'a> Iterator for RowViewMut<&'a mut T, T> {
+impl<'a, T: 'a, D: SquareDimension> Iterator for RowViewMut<&'a mut T, T, D> {
     type Item = &'a mut T;
     fn next(&mut self) -> Option<&'a mut T> {
-        if self.col >= self.rank {
+        if self.col >= self.rank.to_usize() {
             None
         } else {
             unsafe {
@@ -143,33 +145,33 @@ impl<'a, T: 'a> Iterator for RowViewMut<&'a mut T, T> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.rank - self.col;
+        let remaining = self.rank.to_usize() - self.col;
         (remaining, Some(remaining))
     }
 }
 
-pub struct CornerView<RefType, BaseType> {
+pub struct CornerView<RefType, BaseType, D: SquareDimension> {
     ptr: *const BaseType,
     diagonal_element: usize,
     pos: usize,
-    rank: usize,
+    rank: D,
     col_offset: usize,
     _ref_type: PhantomData<RefType>,
 }
 
-pub struct CornerViewMut<RefType, BaseType> {
+pub struct CornerViewMut<RefType, BaseType, D: SquareDimension> {
     ptr: *mut BaseType,
     diagonal_element: usize,
     pos: usize,
-    rank: usize,
+    rank: D,
     col_offset: usize,
     _ref_type: PhantomData<RefType>,
 }
 
-impl<'a, T: 'a> Iterator for CornerViewMut<&'a mut T, T> {
+impl<'a, T: 'a, D: SquareDimension> Iterator for CornerViewMut<&'a mut T, T, D> {
     type Item = &'a mut T;
     fn next(&mut self) -> Option<&'a mut T> {
-        if self.diagonal_element >= self.rank {
+        if self.diagonal_element >= self.rank.to_usize() {
             None
         } else if self.pos <= self.diagonal_element {
             unsafe {
@@ -177,7 +179,7 @@ impl<'a, T: 'a> Iterator for CornerViewMut<&'a mut T, T> {
                 self.pos += 1;
                 Some(&mut *self.ptr.add(offset))
             }
-        } else if self.pos < self.rank {
+        } else if self.pos < self.rank.to_usize() {
             unsafe {
                 let col = self.pos;
                 let row = self.diagonal_element;
@@ -191,15 +193,15 @@ impl<'a, T: 'a> Iterator for CornerViewMut<&'a mut T, T> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.rank - self.pos;
+        let remaining = self.rank.to_usize() - self.pos;
         (remaining, Some(remaining))
     }
 }
 
-impl<'a, T: 'a> Iterator for CornerView<&'a T, T> {
+impl<'a, T: 'a, D: SquareDimension> Iterator for CornerView<&'a T, T, D> {
     type Item = &'a T;
     fn next(&mut self) -> Option<&'a T> {
-        if self.diagonal_element >= self.rank {
+        if self.diagonal_element >= self.rank.to_usize() {
             None
         } else if self.pos <= self.diagonal_element {
             unsafe {
@@ -207,7 +209,7 @@ impl<'a, T: 'a> Iterator for CornerView<&'a T, T> {
                 self.pos += 1;
                 Some(&*self.ptr.add(offset))
             }
-        } else if self.pos < self.rank {
+        } else if self.pos < self.rank.to_usize() {
             unsafe {
                 let col = self.pos;
                 let row = self.diagonal_element;
@@ -221,31 +223,31 @@ impl<'a, T: 'a> Iterator for CornerView<&'a T, T> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.rank - self.pos;
+        let remaining = self.rank.to_usize() - self.pos;
         (remaining, Some(remaining))
     }
 }
 
-pub struct DiagView<RefType, BaseType> {
+pub struct DiagView<RefType, BaseType, D: SquareDimension> {
     ptr: *const BaseType,
     pos: usize,
-    rank: usize,
+    rank: D,
     _ref_type: PhantomData<RefType>,
 }
 
-pub struct DiagViewMut<RefType, BaseType> {
+pub struct DiagViewMut<RefType, BaseType, D: SquareDimension> {
     ptr: *mut BaseType,
     pos: usize,
-    rank: usize,
+    rank: D,
     _ref_type: PhantomData<RefType>,
 }
 
-impl<'a, T: 'a> Iterator for DiagView<&'a T, T> {
+impl<'a, T: 'a, D: SquareDimension> Iterator for DiagView<&'a T, T, D> {
     type Item = &'a T;
     fn next(&mut self) -> Option<&'a T> {
-        if self.pos >= self.rank {
+        if self.pos >= self.rank.to_usize() {
             None
-        } else if self.pos <= self.rank {
+        } else if self.pos <= self.rank.to_usize() {
             unsafe {
                 let offset = offset_for_col(self.pos, self.pos);
                 self.pos += 1;
@@ -257,17 +259,17 @@ impl<'a, T: 'a> Iterator for DiagView<&'a T, T> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.rank - self.pos;
+        let remaining = self.rank.to_usize() - self.pos;
         (remaining, Some(remaining))
     }
 }
 
-impl<'a, T: 'a> Iterator for DiagViewMut<&'a mut T, T> {
+impl<'a, T: 'a, D: SquareDimension> Iterator for DiagViewMut<&'a mut T, T, D> {
     type Item = &'a mut T;
     fn next(&mut self) -> Option<&'a mut T> {
-        if self.pos >= self.rank {
+        if self.pos >= self.rank.to_usize() {
             None
-        } else if self.pos <= self.rank {
+        } else if self.pos <= self.rank.to_usize() {
             unsafe {
                 let offset = offset_for_col(self.pos, self.pos);
                 self.pos += 1;
@@ -279,26 +281,31 @@ impl<'a, T: 'a> Iterator for DiagViewMut<&'a mut T, T> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.rank - self.pos;
+        let remaining = self.rank.to_usize() - self.pos;
         (remaining, Some(remaining))
     }
 }
 
-impl<T> UpperTriRawData<T>
+impl<T> UpperTriRawData<T, DynSquare>
 where
     T: Copy + Zero,
 {
     fn data_size(&self) -> usize {
-        self.rank * (self.rank + 1) / 2
+        let DynSquare(rank) = self.rank;
+        rank * (rank + 1) / 2
     }
     pub fn new(rank: usize) -> Self {
         let def = T::zero();
         let buf = repeat(def).take(rank * (rank + 1) / 2).collect();
-        Self { buf, rank }
+        Self {
+            buf,
+            rank: DynSquare(rank),
+        }
     }
 
     fn get_offset(&self, row: usize, col: usize) -> Option<usize> {
-        if row > col || col >= self.rank || row >= self.rank {
+        let DynSquare(rank) = self.rank;
+        if row > col || col >= rank || row >= rank {
             return None;
         } else {
             return Some(offset_for_col(col, row));
@@ -323,7 +330,7 @@ where
         self.buf.get_mut(offset)
     }
 
-    pub(crate) fn get_raw_col<'a>(&'a self, col: usize) -> ColView<&'a T, T> {
+    pub(crate) fn get_raw_col<'a>(&'a self, col: usize) -> ColView<&'a T, T, DynSquare> {
         ColView {
             ptr: self.buf.as_ptr(),
             col_num: col,
@@ -334,7 +341,10 @@ where
         }
     }
 
-    pub(crate) fn get_raw_col_mut<'a>(&'a mut self, col: usize) -> ColViewMut<&'a mut T, T> {
+    pub(crate) fn get_raw_col_mut<'a>(
+        &'a mut self,
+        col: usize,
+    ) -> ColViewMut<&'a mut T, T, DynSquare> {
         ColViewMut {
             ptr: self.buf.as_mut_ptr(),
             col_num: col,
@@ -345,7 +355,7 @@ where
         }
     }
 
-    pub(crate) fn get_raw_row<'a>(&'a self, row: usize) -> RowView<&'a T, T> {
+    pub(crate) fn get_raw_row<'a>(&'a self, row: usize) -> RowView<&'a T, T, DynSquare> {
         RowView {
             ptr: self.buf.as_ptr(),
             row_num: row,
@@ -355,7 +365,10 @@ where
         }
     }
 
-    pub(crate) fn get_raw_row_mut<'a>(&'a mut self, row: usize) -> RowViewMut<&'a mut T, T> {
+    pub(crate) fn get_raw_row_mut<'a>(
+        &'a mut self,
+        row: usize,
+    ) -> RowViewMut<&'a mut T, T, DynSquare> {
         RowViewMut {
             ptr: self.buf.as_mut_ptr(),
             row_num: row,
@@ -365,7 +378,10 @@ where
         }
     }
 
-    pub(crate) fn get_corner<'a>(&'a self, diagonal_element: usize) -> CornerView<&'a T, T> {
+    pub(crate) fn get_corner<'a>(
+        &'a self,
+        diagonal_element: usize,
+    ) -> CornerView<&'a T, T, DynSquare> {
         CornerView {
             ptr: self.buf.as_ptr(),
             diagonal_element,
@@ -379,7 +395,7 @@ where
     pub(crate) fn get_corner_mut<'a>(
         &'a mut self,
         diagonal_element: usize,
-    ) -> CornerViewMut<&'a mut T, T> {
+    ) -> CornerViewMut<&'a mut T, T, DynSquare> {
         CornerViewMut {
             ptr: self.buf.as_mut_ptr(),
             diagonal_element,
@@ -390,7 +406,7 @@ where
         }
     }
 
-    pub(crate) fn get_diag(&self) -> DiagView<&T, T> {
+    pub(crate) fn get_diag(&self) -> DiagView<&T, T, DynSquare> {
         DiagView {
             ptr: self.buf.as_ptr(),
             pos: 0,
@@ -399,7 +415,7 @@ where
         }
     }
 
-    pub(crate) fn get_diag_mut(&mut self) -> DiagViewMut<&mut T, T> {
+    pub(crate) fn get_diag_mut(&mut self) -> DiagViewMut<&mut T, T, DynSquare> {
         DiagViewMut {
             ptr: self.buf.as_mut_ptr(),
             pos: 0,
@@ -412,32 +428,33 @@ where
         &mut self,
         iter: Itr,
     ) {
-        let new = self.rank + 1;
+        let DynSquare(rank) = self.rank;
+        let new = rank + 1;
 
         let default = T::zero();
         let new_iter = iter.map(|x| *x).chain(repeat(default)).take(new);
 
         self.buf.reserve(new); //Could probably bypass this if we can assure that new iter has trusted_len
         self.buf.extend(new_iter);
-        self.rank += 1;
+        self.rank.grow();
     }
 
     pub(crate) fn push_final_col_iter_owned<Itr: Iterator<Item = T>>(&mut self, iter: Itr) {
-        let new = self.rank + 1;
+        let new = self.rank.0 + 1;
 
         let default = T::zero();
         let new_iter = iter.map(|x| x).chain(repeat(default)).take(new);
 
         self.buf.reserve(new); //Could probably bypass this if we can assure that new iter has trusted_len
         self.buf.extend(new_iter);
-        self.rank += 1;
+        self.rank.grow();
     }
 
     pub fn push_final_col(&mut self, vec: &[T]) {
         self.push_final_col_iter(vec.iter())
     }
 
-    pub fn map<B, F: FnMut(&T) -> B>(&self, f: F) -> UpperTriRawData<B> {
+    pub fn map<B, F: FnMut(&T) -> B>(&self, f: F) -> UpperTriRawData<B, DynSquare> {
         let buf = self.buf.iter().map(f).collect();
         UpperTriRawData {
             buf,
@@ -453,7 +470,7 @@ where
     }
 
     pub(crate) fn drop_at(&mut self, index: usize) -> Vec<T> {
-        let mut return_vec = Vec::with_capacity(self.rank);
+        let mut return_vec = Vec::with_capacity(self.rank.0);
         let col_offset = index * (index + 1) / 2;
         let col_end = col_offset + index + 1;
         let tmp = self.buf.drain(Range {
@@ -463,13 +480,13 @@ where
 
         return_vec.extend(tmp);
         let mut removed = index;
-        for col in (index + 1)..self.rank {
+        for col in (index + 1)..self.rank.0 {
             let next_to_remove = offset_for_col(col, index) - removed;
             let t = self.buf.remove(next_to_remove);
             return_vec.push(t);
             removed += 1;
         }
-        self.rank -= 1;
+        self.rank.shrink();
         return_vec
     }
 
@@ -523,13 +540,13 @@ where
     }
 }
 
-impl<'a, T> Add<&'a UpperTriRawData<T>> for &'a UpperTriRawData<T>
+impl<'a, T> Add<&'a UpperTriRawData<T, DynSquare>> for &'a UpperTriRawData<T, DynSquare>
 where
     T: Copy + Zero + for<'b> AddAssign<&'b T>,
 {
-    type Output = UpperTriRawData<T>;
+    type Output = UpperTriRawData<T, DynSquare>;
 
-    fn add(self, rhs: &'a UpperTriRawData<T>) -> Self::Output {
+    fn add(self, rhs: &'a UpperTriRawData<T, DynSquare>) -> Self::Output {
         if rhs.rank >= self.rank {
             let mut return_buf = rhs.buf.clone();
             return_buf
@@ -559,34 +576,34 @@ where
     }
 }
 
-impl<'a, T> SubAssign<&'a UpperTriRawData<T>> for UpperTriRawData<T>
+impl<'a, T> SubAssign<&'a UpperTriRawData<T, DynSquare>> for UpperTriRawData<T, DynSquare>
 where
     T: for<'b> SubAssign<&'b T> + Copy + Zero,
 {
-    fn sub_assign(&mut self, rhs: &'a UpperTriRawData<T>) {
+    fn sub_assign(&mut self, rhs: &'a UpperTriRawData<T, DynSquare>) {
         self.iter_mut()
             .zip(rhs.iter())
             .for_each(|(left, right)| *left -= right);
     }
 }
 
-impl<T> SubAssign<UpperTriRawData<T>> for UpperTriRawData<T>
+impl<T> SubAssign<UpperTriRawData<T, DynSquare>> for UpperTriRawData<T, DynSquare>
 where
     T: SubAssign<T> + Copy + Zero,
 {
-    fn sub_assign(&mut self, rhs: UpperTriRawData<T>) {
+    fn sub_assign(&mut self, rhs: UpperTriRawData<T, DynSquare>) {
         self.iter_mut()
             .zip(rhs.into_iter())
             .for_each(|(left, right)| *left -= right);
     }
 }
 
-impl<T: Display + Zero + Copy> Display for UpperTriRawData<T> {
+impl<T: Display + Zero + Copy> Display for UpperTriRawData<T, DynSquare> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         let space_len = format!("{} ", T::zero()).len();
         let space = repeat(" ").take(space_len).collect::<String>();
         write!(f, "\n")?;
-        (0..self.rank)
+        (0..self.rank.0)
             .map(|row| -> Result<(), std::fmt::Error> {
                 let spaces = repeat(space.clone()).take(row).collect::<String>();
                 write!(f, "\t{}", spaces)?;
@@ -602,44 +619,44 @@ impl<T: Display + Zero + Copy> Display for UpperTriRawData<T> {
     }
 }
 
-impl<'a, T> Add<&'a UpperTriRawData<T>> for UpperTriRawData<T>
+impl<'a, T> Add<&'a UpperTriRawData<T, DynSquare>> for UpperTriRawData<T, DynSquare>
 where
     T: Copy + Zero + for<'b> AddAssign<&'b T>,
 {
-    type Output = UpperTriRawData<T>;
+    type Output = UpperTriRawData<T, DynSquare>;
 
-    fn add(self, rhs: &'a UpperTriRawData<T>) -> Self::Output {
+    fn add(self, rhs: &'a UpperTriRawData<T, DynSquare>) -> Self::Output {
         &self + rhs
     }
 }
 
-impl<'a, T> Add<UpperTriRawData<T>> for &'a UpperTriRawData<T>
+impl<'a, T> Add<UpperTriRawData<T, DynSquare>> for &'a UpperTriRawData<T, DynSquare>
 where
     T: Copy + Zero + for<'b> AddAssign<&'b T>,
 {
-    type Output = UpperTriRawData<T>;
+    type Output = UpperTriRawData<T, DynSquare>;
 
-    fn add(self, rhs: UpperTriRawData<T>) -> Self::Output {
+    fn add(self, rhs: UpperTriRawData<T, DynSquare>) -> Self::Output {
         self + &rhs
     }
 }
 
-impl<'a, T> Add<UpperTriRawData<T>> for UpperTriRawData<T>
+impl<'a, T> Add<UpperTriRawData<T, DynSquare>> for UpperTriRawData<T, DynSquare>
 where
     T: Copy + Zero + for<'b> AddAssign<&'b T>,
 {
-    type Output = UpperTriRawData<T>;
+    type Output = UpperTriRawData<T, DynSquare>;
 
-    fn add(self, rhs: UpperTriRawData<T>) -> Self::Output {
+    fn add(self, rhs: UpperTriRawData<T, DynSquare>) -> Self::Output {
         &self + &rhs
     }
 }
 
-impl<'a, T> AddAssign<&'a UpperTriRawData<T>> for UpperTriRawData<T>
+impl<'a, T> AddAssign<&'a UpperTriRawData<T, DynSquare>> for UpperTriRawData<T, DynSquare>
 where
     T: Copy + Zero + for<'b> AddAssign<&'b T>,
 {
-    fn add_assign(&mut self, rhs: &'a UpperTriRawData<T>) {
+    fn add_assign(&mut self, rhs: &'a UpperTriRawData<T, DynSquare>) {
         self.buf
             .iter_mut()
             .zip(rhs.buf.iter())
@@ -649,24 +666,27 @@ where
     }
 }
 
-impl<T> AddAssign<UpperTriRawData<T>> for UpperTriRawData<T>
+impl<T> AddAssign<UpperTriRawData<T, DynSquare>> for UpperTriRawData<T, DynSquare>
 where
     T: Copy + Zero + for<'b> AddAssign<&'b T>,
 {
-    fn add_assign(&mut self, rhs: UpperTriRawData<T>) {
+    fn add_assign(&mut self, rhs: UpperTriRawData<T, DynSquare>) {
         *self += &rhs;
     }
 }
 
 #[cfg(test)]
 mod test {
+    use crate::upper_tri_data::DynSquare;
     use crate::upper_tri_data::UpperTriRawData;
     use std::iter::repeat;
 
     #[test]
-    fn test_some_junk() {
+    /// The row and column access is strictly above and to the right of the diagonal so the
+    /// column above position zero has length 0.  The column above position 1 has length 1 etc.
+    fn test_sizes() {
         let hundurd: usize = 100;
-        let mut b = UpperTriRawData::<f32>::new(hundurd);
+        let mut b = UpperTriRawData::<f32, DynSquare>::new(hundurd);
 
         let mut val = 0.0;
         let row_index = 53;
@@ -677,23 +697,23 @@ mod test {
         let c = b.get_raw_row(row_index).map(|x| *x).collect::<Vec<_>>();
         assert_eq!(
             c,
-            (0..(hundurd - row_index))
+            (0..(hundurd - row_index - 1))
                 .map(|x| x as f32)
                 .collect::<Vec<_>>()
         );
-        let d = b.get_raw_row(hundurd - 1).collect::<Vec<_>>();
+        let d = b.get_raw_row(hundurd - 2).collect::<Vec<_>>();
         assert_eq!(d.len(), 1);
-        let e = b.get_raw_col(0).collect::<Vec<_>>();
+        let e = b.get_raw_col(1).collect::<Vec<_>>();
         assert_eq!(e.len(), 1);
         let row = b.get_raw_row(0).collect::<Vec<_>>();
-        assert_eq!(row.len(), hundurd);
+        assert_eq!(row.len(), hundurd - 1);
         let col = b.get_raw_col(hundurd - 1).collect::<Vec<_>>();
-        assert_eq!(col.len(), hundurd);
+        assert_eq!(col.len(), hundurd - 1);
     }
 
     #[test]
     fn test_element_access() {
-        let mut upper_tri = UpperTriRawData::<usize>::new(0);
+        let mut upper_tri = UpperTriRawData::<usize, DynSquare>::new(0);
         for i in 0..10 {
             let iter = (0..(i + 1)).rev();
             upper_tri.push_final_col_iter_owned(iter);
@@ -710,29 +730,29 @@ mod test {
     /// We're testing that if we access out of bounds we get empty iterators
     /// we also test that if we're in bounds we've got the right limits
     fn test_row_col_access() {
-        let mut upper_tri = UpperTriRawData::<usize>::new(10);
+        let mut upper_tri = UpperTriRawData::<usize, DynSquare>::new(10);
         let x: i32 = upper_tri.get_raw_col(1).map(|_| 1).sum();
-        assert_eq!(x, 2); // index 1 is the second col ... arrays start at 0
+        assert_eq!(x, 1); // index 1 is the second col ... arrays start at 0
 
-        let x: i32 = upper_tri.get_raw_col(11).map(|_| 1).sum();
+        let x: i32 = upper_tri.get_raw_col(10).map(|_| 1).sum();
         assert_eq!(x, 0);
 
         let x: i32 = upper_tri.get_raw_col_mut(1).map(|_| 1).sum();
-        assert_eq!(x, 2);
+        assert_eq!(x, 1);
 
-        let x: i32 = upper_tri.get_raw_col_mut(11).map(|_| 1).sum();
+        let x: i32 = upper_tri.get_raw_col_mut(10).map(|_| 1).sum();
         assert_eq!(x, 0);
 
-        let x: i32 = upper_tri.get_raw_row(11).map(|_| 1).sum();
+        let x: i32 = upper_tri.get_raw_row(10).map(|_| 1).sum();
         assert_eq!(x, 0);
 
         let x: i32 = upper_tri.get_raw_row(0).map(|_| 1).sum();
-        assert_eq!(x, 10);
-        let x: i32 = upper_tri.get_raw_row_mut(11).map(|_| 1).sum();
+        assert_eq!(x, 9);
+        let x: i32 = upper_tri.get_raw_row_mut(10).map(|_| 1).sum();
         assert_eq!(x, 0);
 
         let x: i32 = upper_tri.get_raw_row_mut(0).map(|_| 1).sum();
-        assert_eq!(x, 10);
+        assert_eq!(x, 9);
 
         let x: i32 = upper_tri.get_corner(0).map(|_| 1).sum();
         assert_eq!(x, 10);
@@ -747,7 +767,7 @@ mod test {
     #[test]
     fn test_creation() {
         let ten: usize = 10;
-        let mut upper_tri = UpperTriRawData::<usize>::new(ten);
+        let mut upper_tri = UpperTriRawData::<usize, DynSquare>::new(ten);
         assert_eq!(upper_tri.buf.len(), 10 * 11 / 2);
         let vec = (0..11).collect::<Vec<_>>();
         upper_tri.push_final_col(&vec);
@@ -755,13 +775,13 @@ mod test {
         // (arrays start at 0)
         upper_tri.drop_at(4);
         let col = upper_tri.get_raw_col(9).map(|x| *x).collect::<Vec<_>>();
-        assert_eq!(vec![0, 1, 2, 3, 4, 6, 7, 8, 9, 10], col);
+        assert_eq!(vec![0, 1, 2, 3, 4, 6, 7, 8, 9], col);
     }
     #[test]
     fn test_addition() {
         let ten: usize = 10;
-        let mut upper_tri_1 = UpperTriRawData::<isize>::new(1);
-        let mut upper_tri_2 = UpperTriRawData::<isize>::new(1);
+        let mut upper_tri_1 = UpperTriRawData::<isize, DynSquare>::new(1);
+        let mut upper_tri_2 = UpperTriRawData::<isize, DynSquare>::new(1);
         upper_tri_1.push_final_col_iter(repeat(&(-1)));
         upper_tri_1.push_final_col_iter(repeat(&1));
         upper_tri_2.push_final_col_iter(repeat(&1));
@@ -770,7 +790,7 @@ mod test {
         let upper_tri_3 = upper_tri_1 + upper_tri_2;
         let second_col = upper_tri_3.get_raw_col(1).map(|x| *x).collect::<Vec<_>>();
         let third_col = upper_tri_3.get_raw_col(2).map(|x| *x).collect::<Vec<_>>();
-        assert_eq!(second_col, vec![0, 0]);
-        assert_eq!(third_col, vec![2, 2, 2]);
+        assert_eq!(second_col, vec![0]);
+        assert_eq!(third_col, vec![2, 2]);
     }
 }


### PR DESCRIPTION
We've got a dimension trait that we should be able to make generic for staticly sized matrices.  Turns out I had broken the tests already in my other lib, when I decided row and column access should be strictly above and to the left of the diagonal.